### PR TITLE
refactor: myUnits from array to dictionary and renamed to myEntities

### DIFF
--- a/src/reducers/entityReducer.jsx
+++ b/src/reducers/entityReducer.jsx
@@ -15,12 +15,11 @@ import { RIGHT_CLICK, LEFT_CLICK } from '../constants/inputEvents';
 import { entityTypes } from '../entities/entityTypes';
 
 const createInitialState = (viewportWorldLocation) => {
-    const myUnits = []; // times(5, () => { return testEntity.generate() });
+    const myUnits = {}; // times(5, () => { return testEntity.generate() });
     // console.log('entityManager.createInitialState myUnit=', myUnits)
     return {
-        myUnits: myUnits,
-        myUnitsDict: {},
-        otherUnits: [],
+        myUnits,
+        otherUnits: {},
         selectedUnits: [],
         perf: {},
         actionsToServer: []  // a queue of actions needed to be sent to server
@@ -65,22 +64,6 @@ const hydrateEntityFromServer = (receivedEntity, entityTypes, existingEntitiesDi
         });
     //onsole.log(`hydrateEntityFromServer ${newEntity.name}`, hydrated);
     return newEntity;
-}
-
-const createMyUnitsDictionary = (state) => {
-    const startingDict = state.myUnitsById || {};
-    const myUnitsById = state.myUnits.reduce((acc, unit) => {
-        if (!acc[unit.id]) {
-            acc[unit.id] = unit;
-            return acc;
-        }
-        acc[unit.id] = {
-            ...acc[unit.id],
-            ...unit
-        }
-        return acc;
-    }, startingDict);
-    return myUnitsById;
 }
 
 const STARTUP = 'STARTUP';

--- a/src/reducers/entityReducer.jsx
+++ b/src/reducers/entityReducer.jsx
@@ -15,11 +15,11 @@ import { RIGHT_CLICK, LEFT_CLICK } from '../constants/inputEvents';
 import { entityTypes } from '../entities/entityTypes';
 
 const createInitialState = (viewportWorldLocation) => {
-    const myUnits = {}; // times(5, () => { return testEntity.generate() });
-    // console.log('entityManager.createInitialState myUnit=', myUnits)
+    const myEntities = {}; // times(5, () => { return testEntity.generate() });
+    // console.log('entityManager.createInitialState myUnit=', myEntities)
     return {
-        myUnits,
-        otherUnits: {},
+        myEntities,
+        otherEntities: {},
         selectedUnits: [],
         perf: {},
         actionsToServer: []  // a queue of actions needed to be sent to server
@@ -46,13 +46,13 @@ const hydrateNewEntityFromServer = (receivedEntity, entityTypes) => {
 }
 
 const updateEntitiesInState = (targetState, source, hydrate) => {
-    const { myUnits, otherUnits } = targetState;
+    const { myEntities, otherEntities } = targetState;
     const myOwnerId = 'player.1';
     console.warn('updateEntitiesInState still using hard-coded ownerId',myOwnerId)
     source.forEach((sourceEntity) => {
         const { id: entityId, ownerId } = sourceEntity;
         //const { ownerId } = sourceEntity;
-        const targetDictionary= ownerId === myOwnerId ? myUnits : otherUnits;
+        const targetDictionary= ownerId === myOwnerId ? myEntities : otherEntities;
         const targetEntity = targetDictionary[entityId];
         if (targetEntity) {
             Object.entries(sourceEntity).forEach(([field, value]) => {
@@ -198,8 +198,8 @@ const entityReducer = (state, action) => {
             const { path, payload, entityId } = action;
             return state;
         case ADD_TO_MY_ENTITIES:
-            console.warn('entityReducer ADD_TO_MY_ENTITIES has not been updated to treat state.myUnits as an object (it expects an array)')
-            state.myUnits = union(state.myUnits, [action.payload]);
+            console.warn('entityReducer ADD_TO_MY_ENTITIES has not been updated to treat state.myEntities as an object (it expects an array)')
+            state.myEntities = union(state.myEntities, [action.payload]);
             return state;
         case RECEIVED_VISIBLE_ENTITIES:
             const statsPath = `queryResults[${RECEIVED_VISIBLE_ENTITIES}].stats`;

--- a/src/reducers/entityReducer.jsx
+++ b/src/reducers/entityReducer.jsx
@@ -198,6 +198,7 @@ const entityReducer = (state, action) => {
             const { path, payload, entityId } = action;
             return state;
         case ADD_TO_MY_ENTITIES:
+            console.warn('entityReducer ADD_TO_MY_ENTITIES has not been updated to treat state.myUnits as an object (it expects an array)')
             state.myUnits = union(state.myUnits, [action.payload]);
             return state;
         case RECEIVED_VISIBLE_ENTITIES:
@@ -206,37 +207,12 @@ const entityReducer = (state, action) => {
                 timeOfLastResult: 0,
                 numReceived: 0
             });
-            // console.log(RECEIVED_VISIBLE_ENTITIES, numReceived)
             if (!timeOfLastResult) {
                 console.log(action.payload)
             }
             const { getEntitiesICanSee } = action.payload;
-            // Objectives:
-            // 1. update myEntities from server
-            //    - add any new units
-            //    - update fields on existing units
-            //    - filter out units that don't belong to the player 
-            //      (or put them in another structure)
-
-            updateEntitiesInState(state, getEntitiesICanSee, hydrateNewEntityFromServer)
-
-            // let unitDict = createMyUnitsDictionary(state);
-            // state.myUnits = getEntitiesICanSee
-            //     .filter(entity => entity.ownerId === 'player.1')
-            //     .map(entity => hydrateEntityFromServer({
-            //         ...entity, 
-            //         position: [
-            //             entity.position.x,
-            //             entity.position.y,
-            //             entity.position.z || 0
-            //         ]},
-            //         entityTypes,
-            //         unitDict));
-            // state.myUnitsById = createMyUnitsDictionary(state);
-            
-            
-            // console.log('state.myUnits', state.myUnits)
-            //state.otherUnits = action.payload.fil
+    
+            updateEntitiesInState(state, getEntitiesICanSee, hydrateNewEntityFromServer);
             set(state, `${statsPath}.numReceived`, numReceived+1);
             set(state, `${statsPath}.timeOfLastResult`, Date.now());
             

--- a/src/reducers/entityReducer.jsx
+++ b/src/reducers/entityReducer.jsx
@@ -57,6 +57,15 @@ const updateEntitiesInState = (targetState, source, hydrate) => {
         if (targetEntity) {
             Object.entries(sourceEntity).forEach(([field, value]) => {
                 if (field[0]==='_') return;
+                if (field === 'position') {
+                    console.log(`updating ${entityId}.${field} to ${sourceEntity[field]}`)
+                    targetEntity.position = [
+                        sourceEntity[field].x,
+                        sourceEntity[field].y,
+                        sourceEntity[field].z || 0
+                    ];
+                    return;
+                }
                 console.log(`updating ${entityId}.${field} to ${sourceEntity[field]}`)
                 targetEntity[field] = sourceEntity[field];
             })

--- a/src/stories/molecules/EntityManager/EntityManager.jsx
+++ b/src/stories/molecules/EntityManager/EntityManager.jsx
@@ -46,8 +46,8 @@ export const EntityManager = ({gameReducer, userReducer, entityReducer, worldSta
       <boxGeometry />
       <meshStandardMaterial />
       {
-        entityState.myUnits && entityState.myUnits.map((entity) => {
-          return (<EntityInstance key={entity.id} entity={entity} entityReducer={entityReducer} />);
+        entityState.myUnits && Object.entries(entityState.myUnits).map(([id, entity]) => {
+          return (<EntityInstance key={id} entity={entity} entityReducer={entityReducer} />);
         })
       }
       {entityState?.pointerData && pointerEntity(entityState.pointerData)}

--- a/src/stories/molecules/EntityManager/EntityManager.jsx
+++ b/src/stories/molecules/EntityManager/EntityManager.jsx
@@ -46,7 +46,7 @@ export const EntityManager = ({gameReducer, userReducer, entityReducer, worldSta
       <boxGeometry />
       <meshStandardMaterial />
       {
-        entityState.myUnits && Object.entries(entityState.myUnits).map(([id, entity]) => {
+        entityState.myEntities && Object.entries(entityState.myEntities).map(([id, entity]) => {
           return (<EntityInstance key={id} entity={entity} entityReducer={entityReducer} />);
         })
       }

--- a/src/stories/molecules/ViewportTiles/ViewportTiles.jsx
+++ b/src/stories/molecules/ViewportTiles/ViewportTiles.jsx
@@ -82,7 +82,7 @@ export const ViewportTiles = ({client, gameReducer, userReducer, entityReducer, 
   const {loading, error, data, startPolling, stopPolling} = useQuery(
     GET_ENTITIES_I_CAN_SEE, 
     {
-      pollInterval: 500,
+      pollInterval: 10_000,
       onCompleted: data => entityDispatch({ 
         type: RECEIVED_VISIBLE_ENTITIES,
         payload: data 

--- a/src/stories/organisms/Debug/Debug.jsx
+++ b/src/stories/organisms/Debug/Debug.jsx
@@ -33,9 +33,9 @@ export const Debug = ({userState, gameState, performance, entityReducer}) => {
                 </div>
             }
             { 
-                entityState?.myUnits.length > 0 && 
-                <div>myUnits.length {entityState.myUnits.length}
-                {entityState.myUnits.map((entity) => (
+                Object.keys(entityState?.myUnits).length > 0 && 
+                <div>myUnits.length {Object.keys(entityState.myUnits).length}
+                {Object.entries(entityState.myUnits).map(([id, entity]) => (
                    <div key={entity.id}>{entity.id}<br />x: {entity.position[0]}<br />y: {entity.position[1]}<br />z: {entity.position[2]}</div>
                    ))}
                 </div>

--- a/src/stories/organisms/Debug/Debug.jsx
+++ b/src/stories/organisms/Debug/Debug.jsx
@@ -33,9 +33,9 @@ export const Debug = ({userState, gameState, performance, entityReducer}) => {
                 </div>
             }
             { 
-                Object.keys(entityState?.myUnits).length > 0 && 
-                <div>myUnits.length {Object.keys(entityState.myUnits).length}
-                {Object.entries(entityState.myUnits).map(([id, entity]) => (
+                Object.keys(entityState?.myEntities).length > 0 && 
+                <div>myEntities.length {Object.keys(entityState.myEntities).length}
+                {Object.entries(entityState.myEntities).map(([id, entity]) => (
                    <div key={entity.id}>{entity.id}<br />x: {entity.position[0]}<br />y: {entity.position[1]}<br />z: {entity.position[2]}</div>
                    ))}
                 </div>


### PR DESCRIPTION
Work:
- Converted myUnits and otherUnits from arrays to dictionaries and renamed to myEntities and otherEntities, respectively
- Refactored entityReducer and hydrate such that references to existing entities will not be lost when receiving updates from the backup

Callouts:
- Added console.warn statements to call out additional work which I'm putting off for now because those sections of code will need to be refactored or removed anyway once entity creation and other mutations are moved to the backend
- ThreeJS's native datatypes for position involve arrays, so it probably makes sense to refactor the position type on the backend to use arrays instead of the current pattern of an object that holds x, y, and z fields and having to transform that to an array (this happens in schism-ui's updateEntitiesInState)